### PR TITLE
use lowercase for image name

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,8 @@
 version: "3"
 services:
-    urlTracker:
+    urltracker:
         build: .
-        container_name: "urlTracker"
+        container_name: "urltracker"
         restart: always
         ports:
             - "8080:1337"


### PR DESCRIPTION
Docker only allows lowercase letters for image names, otherwise running the build command would return an error.